### PR TITLE
 Fix missing imports 

### DIFF
--- a/CNVD-2020-10487-Tomcat-Ajp-lfi.py
+++ b/CNVD-2020-10487-Tomcat-Ajp-lfi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #CNVD-2020-10487  Tomcat-Ajp lfi
 #by ydhcui
+from io import StringIO
 import struct
 
 # Some references:

--- a/threading-CNVD-2020-10487-Tomcat-Ajp-lfi.py
+++ b/threading-CNVD-2020-10487-Tomcat-Ajp-lfi.py
@@ -5,10 +5,11 @@ import time
 import os
 import re
 import struct
+import sys
 import requests
 import Queue
 import requests
-
+from io import StringIO
 
 
 http_URL = []


### PR DESCRIPTION


[flake8](http://flake8.pycqa.org) testing of https://github.com/Kit4y/CNVD-2020-10487-Tomcat-Ajp-lfi-Scanner on Python 3.8.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./threading-CNVD-2020-10487-Tomcat-Ajp-lfi.py:26:3: F821 undefined name 'sys'
		sys.exit(0)
  ^
./threading-CNVD-2020-10487-Tomcat-Ajp-lfi.py:163:12: F821 undefined name 'StringIO'
		stream = StringIO(raw_packet)
           ^
./CNVD-2020-10487-Tomcat-Ajp-lfi.py:127:12: F821 undefined name 'StringIO'
		stream = StringIO(raw_packet)
           ^
3     F821 undefined name 'StringIO'
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

